### PR TITLE
Fixed  incorrect $LT_URL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ languagetool-cli sample.md > output.md
 If you would like to use a different URL for the LanguageTool service, set the `LT_URL` environment variable like so:
 
 ```sh
-export LT_URL="http://localhost:8081/v2/check"
+export LT_URL="http://localhost:8081/v2"
 ```


### PR DESCRIPTION
The example URL for `LT_URL` in the README.md does not work. The trailing `/check` needs to be removed.